### PR TITLE
policyfile_loader now puts policyfiles in a _default policygroup as defined by an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ This file is used to list changes made in each version of the managed-chef-serve
 
 - legacy loader skip an empty cookbook list
 
+# 0.6.2
+
+- policyfile_loader now puts policyfiles in a _default policygroup as defined by an attribute.
+
 # BACKLOG
 
 - maintenance tasks

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Takes the `node['mcs']['cookbooks']['dir']`, `node['mcs']['environments']['dir']
 
 ## policyfile_loader ##
 
-Takes the `node['mcs']['policyfile']['dir']` and parses any `.lock.json` files to determine which policyfile archives to load into the local Chef server.
+Takes the `node['mcs']['policyfile']['dir']` and parses any `.lock.json` files to determine which policyfile archives to load into the local Chef server. For now, these are assigned to `node['mcs']['policyfile']['group']`.
 
 # Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,3 +54,4 @@ default['mcs']['roles']['dir'] = nil
 
 # policyfile_loader recipe
 default['mcs']['policyfile']['dir'] = nil
+default['mcs']['policyfile']['group'] = '_default'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures a Chef server'
 long_description 'Installs and configures a Chef server'
-version '0.6.1'
+version '0.6.2'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 supports 'redhat'

--- a/recipes/policyfile_loader.rb
+++ b/recipes/policyfile_loader.rb
@@ -13,6 +13,7 @@ node.override['chefdk']['channel'] = :stable
 # chef push-archive POLICY_GROUP base-VERSION.tgz -c config_file --debug
 
 policydir = node['mcs']['policyfile']['dir']
+policygroup = node['mcs']['policyfile']['group']
 configrb = node['mcs']['managed_user']['dir'] + '/config.rb'
 
 # find the local policyfiles
@@ -29,10 +30,10 @@ unless policydir.nil?
     filename = policydir + '/' + policyname + '-' + revision + '.tgz'
 
     # push the archive to the policygroup under the policy name
-    execute "chef push-archive #{policyname} #{filename}" do
-      command "chef push-archive #{policyname} #{filename} -c #{configrb}"
+    execute "chef push-archive #{policygroup} #{filename}" do
+      command "chef push-archive #{policygroup} #{filename} -c #{configrb}"
       # add a guard to check if chef show-policy indicates the policy is already installed
-      not_if "chef show-policy #{policyname} -c #{configrb} | grep '* #{policyname}:' | grep #{short_rev}"
+      not_if "chef show-policy #{policyname} -c #{configrb} | grep '* #{policygroup}:' | grep #{short_rev}"
     end
   end
 end

--- a/test/integration/policyfiles/default_test.rb
+++ b/test/integration/policyfiles/default_test.rb
@@ -10,7 +10,19 @@ describe command('chef') do
 end
 
 describe command('chef show-policy -c /etc/opscode/managed/config.rb') do
-  its ('stdout') { should match /\* base:        bea04861be$/ }
-  its ('stdout') { should match /\* beaglebone:  d99228eafe$/ }
-  its ('stdout') { should match /\* macbookpro:  3e28786370$/ }
+  its ('stdout') { should match /\* _default:  bea04861be$/ }
+  its ('stdout') { should match /\* _default:  d99228eafe$/ }
+  its ('stdout') { should match /\* _default:  3e28786370$/ }
+end
+
+describe command('chef show-policy base -c /etc/opscode/managed/config.rb') do
+  its ('stdout') { should match /\* _default:  bea04861be$/ }
+end
+
+describe command('chef show-policy beaglebone -c /etc/opscode/managed/config.rb') do
+  its ('stdout') { should match /\* _default:  d99228eafe$/ }
+end
+
+describe command('chef show-policy macbookpro -c /etc/opscode/managed/config.rb') do
+  its ('stdout') { should match /\* _default:  3e28786370$/ }
 end


### PR DESCRIPTION
Fixes https://github.com/mattray/managed-chef-server-cookbook/issues/9

Signed-off-by: Matt Ray <matthewhray@gmail.com>
