### PR TITLE
Updates made:

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,10 @@ default['mcs']['roles']['dir'] = nil
 # policyfile_loader recipe
 default['mcs']['policyfile']['dir'] = nil
 default['mcs']['policyfile']['group'] = '_default'
+
+# added to ensure the chef-server-ctl test won't fail becasue of ldap integration
+default['mcs']['skip_test'] = false
+
+# added to pass custom config to chef server
+# for details refer to https://github.com/chef-cookbooks/chef-server#configuring-chef-server
+default['chef-server']['configuration'] = ''

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -112,4 +112,5 @@ execute 'verify the chef-server is working as expected' do
   command 'chef-server-ctl test'
   action :nothing
   subscribes :run, 'chef_ingredient[chef-server]'
+  not_if { node['mcs']['skip_test'] }
 end


### PR DESCRIPTION
attribues/default.rb
- default['mcs']['skip_test'] => disable chef-server-ctl test
- default['chef-server']['configuration'] => allow the cookbook to pass custom c
onfig to chef-server

recipes/default.rb
- add conditional execution to chef-server-ctl