### PR TITLE
Added support for policyfiles to set their policy group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,12 @@ This file is used to list changes made in each version of the managed-chef-serve
 - [https://github.com/mattray/managed-chef-server-cookbook/pull/17](added skipping the Chef Server pedant tests)
 
 
+# 0.9.0
+
+- Added support for policyfiles to set their policy group by setting the `['mcs']['policyfile']['group']` attribute
+
 # BACKLOG
 - maintenance tasks
-sudo /opt/chef/embedded/bin/inspec exec inspec-chef-server --attrs=config.yml
 sudo /opt/chef/embedded/bin/inspec exec https://github.com/chef/inspec-chef-server.git --attrs=config.yml
 inspec exec https://github.com/mattray/inspec-chef-server/tree/rhel --attrs=config.yml
 inspec exec https://github.com/mattray/inspec-chef-server/tree/rhel --target=ssh://192.168.33.22:2222 --user=vagrant --key-files=~/.vagrant.d/insecure_private_key --attrs=test/config.yml --sudo

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Takes the `node['mcs']['cookbooks']['dir']`, `node['mcs']['environments']['dir']
 
 ## policyfile_loader ##
 
-Takes the `node['mcs']['policyfile']['dir']` and parses any `.lock.json` files to determine which policyfile archives to load into the local Chef server. For now, these are assigned to `node['mcs']['policyfile']['group']`.
+Takes the `node['mcs']['policyfile']['dir']` and parses any `.lock.json` files to determine which policyfile archives to load into the local Chef server. Policies will be assigned to the group designated by the `node['mcs']['policyfile']['group']` attribute for the Chef server (`_default` is the default). If the policy itself sets the `node['mcs']['policyfile']['group']` attribute, the policy will be assigned to that group.
 
 # Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures a Chef server'
 long_description 'Installs and configures a Chef server'
-version '0.8.0'
+version '0.9.0'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 supports 'redhat'

--- a/policyfiles/backup.rb
+++ b/policyfiles/backup.rb
@@ -7,3 +7,5 @@ run_list 'managed-chef-server::backup'
 # every 5 minutes for testing
 override['mcs']['backup']['cron']['minute'] = '*/5'
 override['mcs']['backup']['cron']['hour'] = '*'
+
+override['mcs']['skip_test'] = true

--- a/policyfiles/base.rb
+++ b/policyfiles/base.rb
@@ -8,3 +8,5 @@ run_list 'managed-chef-server::default'
 
 # override['chefdk']['package_source'] = '/backups/chefdk-3.1.0-1.el7.x86_64.rpm'
 # override['chef-server']['package_source'] = '/backups/chef-server-core-12.17.33-1.el7.x86_64.rpm'
+
+override['mcs']['skip_test'] = false

--- a/policyfiles/cron.rb
+++ b/policyfiles/cron.rb
@@ -7,3 +7,5 @@ run_list 'managed-chef-server::cron'
 # every 5 minutes for testing
 override['mcs']['cron']['minute'] = '*/5'
 override['mcs']['cron']['options'] = ['-z', '-F min']
+
+override['mcs']['skip_test'] = true

--- a/policyfiles/data_bags.rb
+++ b/policyfiles/data_bags.rb
@@ -6,3 +6,5 @@ run_list 'managed-chef-server::data_bag_loader'
 
 # override['mcs']['restore']['file'] = '/backups/chef-server-backup-201811110055.tgz' # pre-baked with 2 data bag items existing
 override['mcs']['data_bags']['dir'] = '/backups/data_bags'
+
+override['mcs']['skip_test'] = true

--- a/policyfiles/default.rb
+++ b/policyfiles/default.rb
@@ -3,3 +3,5 @@ name 'default'
 include_policy 'base', path: './base.lock.json'
 
 run_list 'managed-chef-server::default'
+
+override['mcs']['skip_test'] = true

--- a/policyfiles/everything.rb
+++ b/policyfiles/everything.rb
@@ -12,3 +12,5 @@ override['mcs']['policyfile']['dir'] = '/backups/policyfiles'
 override['mcs']['cookbooks']['dir'] = '/backups/cookbooks'
 override['mcs']['environments']['dir'] = '/backups/environments'
 override['mcs']['roles']['dir'] = '/backups/roles'
+
+override['mcs']['skip_test'] = false

--- a/policyfiles/legacy.rb
+++ b/policyfiles/legacy.rb
@@ -7,3 +7,5 @@ run_list 'managed-chef-server::legacy_loader'
 override['mcs']['cookbooks']['dir'] = '/backups/cookbooks'
 override['mcs']['environments']['dir'] = '/backups/environments'
 override['mcs']['roles']['dir'] = '/backups/roles'
+
+default['mcs']['skip_test'] = true

--- a/policyfiles/policyfile.rb
+++ b/policyfiles/policyfile.rb
@@ -5,3 +5,5 @@ include_policy 'base', path: './base.lock.json'
 run_list 'managed-chef-server::policyfile_loader'
 
 override['mcs']['policyfile']['dir'] = '/backups/policyfiles'
+
+default['mcs']['skip_test'] = true

--- a/policyfiles/restore.rb
+++ b/policyfiles/restore.rb
@@ -5,3 +5,5 @@ include_policy 'base', path: './base.lock.json'
 run_list 'managed-chef-server::policyfile_loader' # added for inclusion of the chefdk for testing
 
 override['mcs']['restore']['file'] = '/backups/chef-server-backup-201811110055.tgz'
+
+default['mcs']['skip_test'] = true

--- a/recipes/policyfile_loader.rb
+++ b/recipes/policyfile_loader.rb
@@ -13,7 +13,6 @@ node.override['chefdk']['channel'] = :stable
 # chef push-archive POLICY_GROUP base-VERSION.tgz -c config_file --debug
 
 policydir = node['mcs']['policyfile']['dir']
-policygroup = node['mcs']['policyfile']['group']
 configrb = node['mcs']['managed_user']['dir'] + '/config.rb'
 
 # find the local policyfiles
@@ -28,6 +27,11 @@ unless policydir.nil?
     short_rev = revision[0, 9]
     # match the right policyfile archive based on name in lock file
     filename = policydir + '/' + policyname + '-' + revision + '.tgz'
+
+    policygroup = node['mcs']['policyfile']['group']
+    # if the policyfile sets the group, use that value
+    policygroup = plock['default_attributes']['mcs']['policyfile']['group'] unless plock.dig('default_attributes', 'mcs', 'policyfile', 'group').nil?
+    policygroup = plock['override_attributes']['mcs']['policyfile']['group'] unless plock.dig('override_attributes', 'mcs', 'policyfile', 'group').nil?
 
     # push the archive to the policygroup under the policy name
     execute "chef push-archive #{policygroup} #{filename}" do

--- a/test/integration/policyfiles/default_test.rb
+++ b/test/integration/policyfiles/default_test.rb
@@ -12,7 +12,7 @@ end
 describe command('chef show-policy -c /etc/opscode/managed/config.rb') do
   its ('stdout') { should match /\* _default:  bea04861be$/ }
   its ('stdout') { should match /\* _default:  d99228eafe$/ }
-  its ('stdout') { should match /\* _default:  3e28786370$/ }
+  its ('stdout') { should match /\* home:      3e28786370$/ }
 end
 
 describe command('chef show-policy base -c /etc/opscode/managed/config.rb') do
@@ -24,5 +24,6 @@ describe command('chef show-policy beaglebone -c /etc/opscode/managed/config.rb'
 end
 
 describe command('chef show-policy macbookpro -c /etc/opscode/managed/config.rb') do
-  its ('stdout') { should match /\* _default:  3e28786370$/ }
+  its ('stdout') { should match /\* home:      3e28786370$/ }
+  its ('stdout') { should match /\* _default:  \*NOT APPLIED\*$/ }
 end

--- a/test/policyfiles/macbookpro.lock.json
+++ b/test/policyfiles/macbookpro.lock.json
@@ -123,7 +123,11 @@
     }
   },
   "default_attributes": {
-
+      "mcs": {
+          "policyfile": {
+              "group": "home"
+          }
+      }
   },
   "override_attributes": {
     "authorization": {


### PR DESCRIPTION
Policyfiles can set their policy group by setting the `['mcs']['policyfile']['group']` attribute