### PR TITLE
Changes to suit new discoveries

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,6 +65,7 @@ default['mcs']['roles']['dir'] = nil
 default['mcs']['policyfile']['dir'] = nil
 default['mcs']['policyfile']['group'] = '_default'
 default['mcs']['policyfile']['lockfiletype'] = '.lock.json'
+default['mcs']['policyfile']['purge'] = false
 
 # added to allow skipping chef-server-ctl test for already deployed systems
 default['mcs']['skip_test'] = false

--- a/recipes/data_bag_loader.rb
+++ b/recipes/data_bag_loader.rb
@@ -7,76 +7,106 @@ dbdir = node['mcs']['data_bags']['dir']
 configrb = node['mcs']['managed_user']['dir'] + '/config.rb'
 prune = node['mcs']['data_bags']['prune']
 
-# get existing data bags
 existing_dbags = {}
-list = shell_out("knife data bag list -c #{configrb}").stdout.split
-list.each do |dbag|
-  existing_dbags[dbag] = {}
-  items = shell_out!("knife data bag show #{dbag} -c #{configrb}").stdout.split
-  items.each do |item|
-    content = JSON.load(shell_out!("knife data bag show #{dbag} #{item} -c #{configrb} --format json").stdout)
-    existing_dbags[dbag][item] = content
+
+# get existing data bags
+ruby_block 'list existing data bags' do
+  block do
+    list = shell_out("knife data bag list -c #{configrb}").stdout.split
+    list.each do |dbag|
+      existing_dbags[dbag] = {}
+      items = shell_out!("knife data bag show #{dbag} -c #{configrb}").stdout.split
+      items.each do |item|
+        content = JSON.load(shell_out!("knife data bag show #{dbag} #{item} -c #{configrb} --format json").stdout)
+        existing_dbags[dbag][item] = content
+      end
+    end
+    node.run_state['existing_dbags'] = existing_dbags
+    # puts "LLLL #{existing_dbags.to_json}"
+    # puts "MMMM #{node.run_state['existing_dbags'].to_json}"
   end
 end
 
-# get list of data bags to manage
 file_dbags = {}
 file_dbags_files = {} # file associated with the data bag items
-unless dbdir.nil?
-  Dir.foreach(dbdir) do |dbag|
-    next if ['.', '..'].member?(dbag)
-    file_dbags[dbag] = {}
-    file_dbags_files[dbag] = {}
-    bagdir = dbdir + '/' + dbag
-    Dir.foreach(bagdir) do |itemfile| # get items for each
-      next if ['.', '..'].member?(itemfile)
-      item = JSON.parse(File.read(bagdir + '/' + itemfile))
-      file_dbags[dbag][item['id']] = item
-      file_dbags_files[dbag][item['id']] = itemfile
+node.run_state['file_dbags'] = {}
+node.run_state['file_dbags_files'] = {}
+
+# get list of data bags to manage
+ruby_block 'get list of data bags to manage' do
+  block do
+    Dir.foreach(dbdir) do |dbag|
+      next if ['.', '..'].member?(dbag)
+      file_dbags[dbag] = {}
+      file_dbags_files[dbag] = {}
+      bagdir = dbdir + '/' + dbag
+      Dir.foreach(bagdir) do |itemfile| # get items for each
+        next if ['.', '..'].member?(itemfile)
+        item = JSON.parse(File.read(bagdir + '/' + itemfile))
+        file_dbags[dbag][item['id']] = item
+        file_dbags_files[dbag][item['id']] = itemfile
+      end
     end
+    node.run_state['file_dbags'] = file_dbags
+    node.run_state['file_dbags_files'] = file_dbags_files
   end
+  not_if { dbdir.nil? }
 end
 
 # if we are pruning we are deleting unmanaged data bags and items
 if prune
-  # existing keys not in new, those are deletes
-  deleted_dbags = existing_dbags.keys - file_dbags.keys
-  deleted_dbags.each do |dbag|
-    execute "knife data bag delete #{dbag}" do
-      command "knife data bag delete #{dbag} -y -c #{configrb}"
+  ruby_block 'delete unused data bags' do
+    block do
+      # existing keys not in new, those are deletes
+      deleted_dbags = node.run_state['existing_dbags'].keys - node.run_state['file_dbags'].keys
+      deleted_dbags.each do |dbag|
+        shell_out("knife data bag delete #{dbag} -y -c #{configrb}")
+      end
     end
   end
-  # existing items not in new, those are deletes
-  shared_dbags = existing_dbags.keys & file_dbags.keys
-  shared_dbags.each do |dbag|
-    deleted_items = existing_dbags[dbag].keys - file_dbags[dbag].keys
-    deleted_items.each do |item|
-      execute "knife data bag delete #{dbag} #{item}" do
-        command "knife data bag delete #{dbag} #{item} -y -c #{configrb}"
+
+  ruby_block 'delete unused data bag items' do
+    block do
+      # existing items not in new, those are deletes (and may be in still existing databags)
+      shared_dbags = node.run_state['existing_dbags'].keys & node.run_state['file_dbags'].keys
+      shared_dbags.each do |dbag|
+        deleted_items = node.run_state['existing_dbags'][dbag].keys - node.run_state['file_dbags'][dbag].keys
+        deleted_items.each do |item|
+          shell_out("knife data bag delete #{dbag} #{item} -y -c #{configrb}")
+        end
       end
     end
   end
 end
 
-# new keys not in existing, those are creates
-new_dbags = file_dbags.keys - existing_dbags.keys
-new_dbags.each do |dbag|
-  execute "knife data bag create #{dbag}" do
-    command "knife data bag create #{dbag} -c #{configrb}"
-  end
-end
-# items new or changed from existing, those are from file
-shared_dbags = file_dbags.keys & existing_dbags.keys
-shared_dbags += new_dbags # don't forget the new ones
-shared_dbags.each do |dbag|
-  file_dbags[dbag].keys.each do |item|
-    # compare existing data bag items with those in the file
-    next if existing_dbags.key?(dbag) &&
-            existing_dbags[dbag].key?(item) &&
-            file_dbags[dbag][item].eql?(existing_dbags[dbag][item])
-    execute "knife data bag from file #{dbag} #{dbag}/#{file_dbags_files[dbag][item]}" do
-      command "knife data bag from file #{dbag} #{dbag}/#{file_dbags_files[dbag][item]} -c #{configrb}"
-      cwd dbdir
+# new databags not in existing need to be created
+ruby_block 'create data bags' do
+  block do
+    new_dbags = node.run_state['file_dbags'].keys - node.run_state['existing_dbags'].keys
+    new_dbags.each do |dbag|
+      print "\nCreating data bag #{dbag}"
+      shell_out("knife data bag create #{dbag} -c #{configrb}")
     end
   end
+  not_if { node.run_state['file_dbags'].empty? }
+end
+
+# new data bag items need to be added to existing or new databags
+ruby_block 'add data bag items' do
+  block do
+    # items new or changed from existing, those are from file
+    shared_dbags = node.run_state['file_dbags'].keys & node.run_state['existing_dbags'].keys
+    shared_dbags += node.run_state['file_dbags'].keys - node.run_state['existing_dbags'].keys
+    # shared_dbags += new_dbags # don't forget the new ones
+    shared_dbags.each do |dbag|
+      node.run_state['file_dbags'][dbag].keys.each do |item|
+        # compare existing data bag items with those in the file
+        next if node.run_state['existing_dbags'].key?(dbag) && node.run_state['existing_dbags'][dbag].key?(item) &&
+                node.run_state['file_dbags'][dbag][item].eql?(node.run_state['existing_dbags'][dbag][item])
+        print "\nAdding file #{dbdir}/#{dbag}/#{node.run_state['file_dbags_files'][dbag][item]} to data bag #{dbag.to_json}"
+        shell_out("knife data bag from file #{dbag} #{dbdir}/#{dbag}/#{node.run_state['file_dbags_files'][dbag][item]} -c #{configrb}")
+      end
+    end
+  end
+  not_if { node.run_state['file_dbags'].empty? }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,8 +107,7 @@ end
 execute 'chef-server-ctl org-user-add' do
   command "chef-server-ctl org-user-add #{org_name} #{user_name} --admin"
   retries 2
-  action :nothing
-  subscribes :run, 'execute[chef-server-ctl user-create]', :immediately
+  not_if "chef-server-ctl user-show #{user_name} -l | grep '^organizations:' | grep ' #{org_name}$'"
 end
 
 execute 'verify the chef-server is working as expected' do

--- a/recipes/policyfile_loader.rb
+++ b/recipes/policyfile_loader.rb
@@ -17,7 +17,11 @@ configrb = node['mcs']['managed_user']['dir'] + '/config.rb'
 
 return if policydir.nil? || policydir.empty?
 
+# policy revisions
 existing_policies = {}
+# policy names
+existing_names = []
+
 policyname = ''
 
 # construct hash of existing policies
@@ -30,9 +34,12 @@ ruby_block 'inspect existing policies' do
         existing_policies[line.split[1] + line.split[2]] = policyname
       else
         policyname = line
+        existing_names << policyname
       end
     end
     node.run_state['existing_policies'] = existing_policies
+    node.run_state['existing_names'] = existing_names
+    # puts "NNNN #{existing_names}"
   end
 end
 
@@ -49,21 +56,23 @@ ruby_block 'load new policies' do
       polindex = policygroup + ':' + plock['revision_id'][0, 10]
       print "\nPushing policy #{plock['name']} #{plock['revision_id'][0, 10]} to policy group #{policygroup}" unless node.run_state['existing_policies'][polindex]
       shell_out("chef push-archive #{policygroup} #{filename} -c #{configrb}") unless node.run_state['existing_policies'][polindex]
-      node.run_state['existing_policies'].delete(polindex)
+      node.run_state['existing_names'].delete(plock['name']) # any policyname encountered in the policydir is to be kept regardless of revision
     end
   end
 end
 
-# after the above block completes, the existing_policies hash only contains policies that don't exist in the policydir
-# so we delete them if that's an option
+# after the above block completes, the existing_names array only contains policies that weren't found in the policydir
+# so we may delete them (if that's an option)
 
 ruby_block 'remove unused policies' do
   block do
-    node.run_state['existing_policies'].each do |_key, pol|
-      print "\nDeleting unused policy #{pol}"
-      shell_out("chef delete-policy #{pol} -c #{configrb}")
+    node.run_state['existing_names'].each do |policy|
+      print "\nDeleting unused policy #{policy}"
+      shell_out("chef delete-policy #{policy} -c #{configrb}")
     end
+    # we could do this here or in the maintenance recipe
+    # shell_out("chef clean-policy-revisions -c #{configrb}")
   end
   only_if { node['mcs']['policyfile']['purge'] }
-  not_if { node.run_state['existing_policies'].empty? }
+  not_if { node.run_state['existing_names'].empty? }
 end


### PR DESCRIPTION
* If we change the organisation name, the existing managed user needs to be added to the new organisation.
* Policyfile loader needs to inspect policies at exec stage so that it picks up on any policies added as part of a data backup restore during the current cookbook run.