### PR TITLE
Minor cleanups for ensuring data bag directory exists and adding admin users on restores.

### DIFF
--- a/recipes/data_bag_loader.rb
+++ b/recipes/data_bag_loader.rb
@@ -22,7 +22,7 @@ end
 # get list of data bags to manage
 file_dbags = {}
 file_dbags_files = {} # file associated with the data bag items
-unless dbdir.nil?
+unless dbdir.nil? || Dir.exist?(dbdir)
   Dir.foreach(dbdir) do |dbag|
     next if ['.', '..'].member?(dbag)
     file_dbags[dbag] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,8 +107,7 @@ end
 execute 'chef-server-ctl org-user-add' do
   command "chef-server-ctl org-user-add #{org_name} #{user_name} --admin"
   retries 2
-  action :nothing
-  subscribes :run, 'execute[chef-server-ctl user-create]', :immediately
+  not_if "chef-server-ctl user-show #{user_name} -l | grep '^organizations:' | grep ' #{org_name}$'"
 end
 
 execute 'verify the chef-server is working as expected' do


### PR DESCRIPTION
Add the admin user to the org if it's missing, not just on a first create.
Ensure the data bag directory exists when loading data bags.